### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,11 +14,11 @@ PID	KEYWORD1
 
 compute	KEYWORD2
 setParams	KEYWORD2
-setUpdateTime  KEYWORD2
-setDirection  KEYWORD2
-setOffset  KEYWORD2
-setLimits  KEYWORD2
-reset  KEYWORD2
+setUpdateTime	KEYWORD2
+setDirection	KEYWORD2
+setOffset	KEYWORD2
+setLimits	KEYWORD2
+reset	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords